### PR TITLE
add python binding to predict_post for ndarray

### DIFF
--- a/Python/RerF.py
+++ b/Python/RerF.py
@@ -112,10 +112,14 @@ def fastRerF(
     forestClass.setParameter("seed", seed)
 
     if CSVFile is not None and Ycolumn is not None:
+        forestClass.setParameter("useRowMajor", 0)
         forestClass.setParameter("CSVFileName", CSVFile)
         forestClass.setParameter("columnWithY", Ycolumn)
         forestClass._growForest()
     elif X is not None and Y is not None:
+        # explicitly say we are using rowMajor
+        forestClass.setParameter("useRowMajor", 1)
+
         num_obs = len(Y)
         num_features = X.shape[1]
         forestClass._growForestnumpy(X, Y, num_obs, num_features)

--- a/Python/RerF.py
+++ b/Python/RerF.py
@@ -128,7 +128,11 @@ def fastRerF(
 
 
 def fastPredict(X, forest):
-    """Runs a prediction on a forest with a given set of data.
+    """Predict class for X.
+
+    The predicted class of an input sample is the majority vote by the 
+    trees in the forest where each vote is the majority class of each 
+    tree's leaf node.
     
     Parameters
     ----------
@@ -146,7 +150,7 @@ def fastPredict(X, forest):
 
     Examples
     --------
-    >>> fastPredict(np.array([0, 0, 0, 0]), forest)
+    >>> fastPredict([0, 1, 2, 3], forest)
     """
 
     X = np.asarray(X)
@@ -159,7 +163,10 @@ def fastPredict(X, forest):
 
 
 def fastPredictPost(X, forest):
-    """Runs a prediction on a forest with a given set of data.
+    """Predict class probabilities for X.
+
+    The predicted class probabilities of an input sample are computed as 
+    the normalized votes of each tree in the forest.  
     
     Parameters
     ----------
@@ -171,13 +178,14 @@ def fastPredictPost(X, forest):
 
     Returns
     -------
-    posterior_probabilites : list of int, shape = [n_classes] or array, shape = [n_samples, n_classes]
-        Returns the class of prediction (int) or predictions (list) 
-        depending on input parameters.
+    posterior_probabilities : list of ints, shape = [n_classes] or array, shape = [n_samples, n_classes]
+        Returns the class probabilities for a single observation (list) or 
+        numpy array of class probabilities for each observation depending 
+        on input parameters.
 
     Examples
     --------
-    >>> fastPredictPost(np.array([0, 0, 0, 0]), forest)
+    >>> fastPredictPost([0, 1, 2, 3], forest)
     """
 
     X = np.asarray(X)

--- a/Python/RerF.py
+++ b/Python/RerF.py
@@ -145,11 +145,47 @@ def fastPredict(X, forest):
     >>> fastPredict(np.array([0, 0, 0, 0]), forest)
     """
 
+    X = np.asarray(X)
+
     if X.ndim == 1:
         predictions = forest._predict(X.tolist())
     else:
         predictions = forest._predict_numpy(X)
     return predictions
+
+
+def fastPredictPost(X, forest):
+    """Runs a prediction on a forest with a given set of data.
+    
+    Parameters
+    ----------
+    X : array_like
+        Numpy ndarray of data, if more than 1 row, run multiple 
+        predictions.
+    forest : pyfp.fpForest
+        Forest to run predictions on
+
+    Returns
+    -------
+    posterior_probabilites : list of int, shape = [n_classes] or array, shape = [n_samples, n_classes]
+        Returns the class of prediction (int) or predictions (list) 
+        depending on input parameters.
+
+    Examples
+    --------
+    >>> fastPredictPost(np.array([0, 0, 0, 0]), forest)
+    """
+
+    X = np.asarray(X)
+
+    if X.ndim == 1:
+        y = forest._predict_post(X.tolist())
+        y_prob = [p / sum(y) for p in y]
+    else:
+        y = forest._predict_post_array(X)
+        y_arr = np.asarray(y)
+        y_prob = y_arr / y_arr.sum(1)[:, None]
+    return y_prob
 
 
 if __name__ == "__main__":

--- a/Python/example.py
+++ b/Python/example.py
@@ -1,4 +1,4 @@
-from RerF import fastRerF, fastPredict
+from RerF import fastRerF, fastPredict, fastPredictPost
 import numpy as np
 from multiprocessing import cpu_count
 
@@ -40,8 +40,13 @@ forest = fastRerF(
 
 forest.printParameters()
 
+# training predictions
 predictions = fastPredict(feat_data, forest)
 # print(predictions)
+
+# training posterior predictions probabilities
+post_pred = fastPredictPost(feat_data, forest)
+# print(post_pred)
 
 print("Error rate", np.mean(predictions != labels))
 

--- a/Python/packedForest.cpp
+++ b/Python/packedForest.cpp
@@ -65,7 +65,28 @@ PYBIND11_MODULE(pyfp, m)
             return predictions;
         })
 
-        .def("predict_post", &fpForest<double>::predictPost, "Returns a vector representing the votes for each class.")
+        .def("_predict_post", &fpForest<double>::predictPost, "Returns a vector representing the votes for each class.")
+
+        .def("_predict_post_array", [](fpForest<double> &self, py::array_t<double, py::array::c_style | py::array::forcecast> mat) {
+            py::buffer_info buf = mat.request();
+            double *ptr = (double *)buf.ptr;
+            int numObservations = buf.shape[0];
+            int numFeatures = buf.shape[1];
+
+            std::vector<double> currObs(numFeatures);
+            std::vector<std::vector<int>> predict_posts(numObservations);
+
+            for (int i = 0; i < numObservations; i++)
+            {
+                for (int j = 0; j < numFeatures; j++)
+                {
+                    currObs[j] = ptr[i * numFeatures + j];
+                }
+                predict_posts[i] = self.predictPost(currObs);
+            }
+            return predict_posts;
+        },
+             "Returns a vector of vectors representing the votes for each class for each observation")
 
         .def("testAccuracy", &fpForest<double>::testAccuracy);
 }

--- a/Python/tests/test_RerF.py
+++ b/Python/tests/test_RerF.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from .helper import get_params
-from ..RerF import fastPredict, fastRerF
+from ..RerF import fastPredict, fastRerF, fastPredictPost
 
 
 def test_fastRerF_CSV_input():
@@ -120,3 +120,47 @@ def test_fastPredict_X_Y_input():
     assert pred_first == 0
     assert pred_last == 2
     assert np.array_equal(pred_all, Y)
+
+
+def test_fastPredictPost_X_Y_input():
+    datafile = "packedForest/res/iris.csv"
+    X = np.genfromtxt(datafile, delimiter=",")
+    feat_data = X[:, 0:4]
+    Y = X[:, 4]
+
+    forest = fastRerF(
+        X=feat_data,
+        Y=Y,
+        forestType="binnedBaseRerF",
+        trees=500,
+        minParent=1,
+        maxDepth=None,
+        numCores=1,
+        mtry=2,
+        seed=30,
+    )
+
+    pred_first = fastPredictPost(feat_data[0, :], forest)
+
+    # length should be number of classes
+    assert len(pred_first) == 3
+    # should sum to 1
+    assert sum(pred_first) == 1
+
+    # pred class should equal the max prob in posterior
+    # index of max in list
+    class_pred_post = max(enumerate(pred_first), key=lambda x: x[1])[0]
+    assert class_pred_post == fastPredict(feat_data[0, :], forest)
+
+    # returns a numpy array
+    pred_all = fastPredictPost(feat_data, forest)
+
+    # shape should be (num obs, num classes)
+    assert pred_all.shape == (150, 3)
+
+    # sum of each row should be 1
+    assert np.array_equal(pred_all.sum(1), np.ones(150))
+
+    # pred class should equal the max prob in posteriors
+    assert np.array_equal(pred_all.argmax(axis=1), fastPredict(feat_data, forest))
+

--- a/Python/tests/test_packedForest.py
+++ b/Python/tests/test_packedForest.py
@@ -65,16 +65,9 @@ def test_predict_post_numpy():
     forest.setParameter("maxDepth", 5)
     forest._growForest()
 
-    # load in 10 obs into a numpy array
+    # load in 20 obs into a numpy array
     nobs = 20
-    obs = np.ndarray((nobs, 5))
-    with open("packedForest/res/iris.csv", "r") as f:
-        line_iter = csv.reader(f, delimiter=",")
-        for i in range(10):
-            obs[i, :] = next(line_iter)
-
-    # remove the labels
-    obs = np.delete(obs, 4, 1)
+    obs = np.random.rand(nobs, 4) * 5
 
     # returns a list of lists
     posts = forest._predict_post_array(obs)

--- a/Python/tests/test_packedForest.py
+++ b/Python/tests/test_packedForest.py
@@ -1,5 +1,3 @@
-import csv
-
 import numpy as np
 import pytest
 

--- a/Python/tests/test_packedForest.py
+++ b/Python/tests/test_packedForest.py
@@ -1,7 +1,11 @@
+import csv
+
+import numpy as np
 import pytest
 
-from .helper import get_params
 import pyfp
+
+from .helper import get_params
 
 
 def test_set_params():
@@ -42,9 +46,45 @@ def test_predict_post():
 
     test_case = [5.1, 3.5, 1.4, 0.2]
 
-    results = forest.predict_post(test_case)
+    results = forest._predict_post(test_case)
 
     assert len(results) == 3
     assert results[0] == 10
     assert results[1] == 0
     assert results[2] == 0
+
+
+def test_predict_post_numpy():
+    forest = pyfp.fpForest()
+    forest.setParameter("CSVFileName", "packedForest/res/iris.csv")
+    forest.setParameter("numTreesInForest", 10)
+    forest.setParameter("minParent", 1)
+    forest.setParameter("columnWithY", 4)
+    forest.setParameter("seed", -1661580697)
+    forest.setParameter("forestType", "binnedBase")
+    forest.setParameter("maxDepth", 5)
+    forest._growForest()
+
+    # load in 10 obs into a numpy array
+    nobs = 20
+    obs = np.ndarray((nobs, 5))
+    with open("packedForest/res/iris.csv", "r") as f:
+        line_iter = csv.reader(f, delimiter=",")
+        for i in range(10):
+            obs[i, :] = next(line_iter)
+
+    # remove the labels
+    obs = np.delete(obs, 4, 1)
+
+    # returns a list of lists
+    posts = forest._predict_post_array(obs)
+
+    # length should be number of nobs
+    assert len(posts) == nobs
+
+    # sum should be nobs * numTrees
+    assert sum([sum(l) for l in posts]) == 10 * nobs
+
+    # sum should be number of trees for each obs
+    for p in posts:
+        assert sum(p) == 10


### PR DESCRIPTION
This adds predict posterior **probabilities** to the RerF module in Python (w/ tests against the module and the bindings).  (It normalizes the "votes" returned by `packedForest` by the total number of votes to give probabilities.

Note, this functionality is currently missing from the `R` binding (@MrAE).

Also, I made Python binding explicitly set `useRowMajor` option when using numpy array input, as opposed to relying on it being set by default in C++.

My quick testing on 6K predictions is that this results in a 2X speedup on returning the posterior predictions, though maybe faster if running even more predictions.