### PR TITLE
Sphinx hide prompt

### DIFF
--- a/docs/_static/js/copybutton.js
+++ b/docs/_static/js/copybutton.js
@@ -1,0 +1,64 @@
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-python .highlight,' +
+                '.highlight-python3 .highlight,' + 
+                '.highlight-pycon .highlight,' +
+		'.highlight-default .highlight')
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide the prompts and output';
+    var show_text = 'Show the prompts and output';
+    var border_width = pre.css('border-top-width');
+    var border_style = pre.css('border-top-style');
+    var border_color = pre.css('border-top-color');
+    var button_styles = {
+        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+        'border-color': border_color, 'border-style': border_style,
+        'border-width': border_width, 'color': border_color, 'text-size': '75%',
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+        'border-radius': '0 3px 0 0'
+    }
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+            button.css(button_styles)
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+        }
+    });
+});
+

--- a/docs/_static/js/copybutton.js
+++ b/docs/_static/js/copybutton.js
@@ -1,11 +1,14 @@
+// Copyright 2014 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+// File originates from the cpython source found in Doc/tools/sphinxext/static/copybutton.js
+
 $(document).ready(function() {
     /* Add a [>>>] button on the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
     var div = $('.highlight-python .highlight,' +
-                '.highlight-python3 .highlight,' + 
+               '.highlight-python3 .highlight,' +
                 '.highlight-pycon .highlight,' +
-		'.highlight-default .highlight')
+                '.highlight-default .highlight')
     var pre = div.find('pre');
 
     // get the styles from the current theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,8 @@
 #
 import os
 import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath("../Python"))
 sys.path.insert(0, os.path.abspath("sphinxext"))
 from github_link import make_linkcode_resolve
 
@@ -40,7 +41,7 @@ release = ""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "numpydoc", "sphinx.ext.linkcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx.ext.linkcode"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -193,8 +194,13 @@ html_context = {
 
 linkcode_resolve = make_linkcode_resolve(
     "RerF",
-    u"https://github.com/neurodata/"
-    "RerF/blob/{revision}/"
-    "Python/{path}#L{lineno}",
+    u"https://github.com/neurodata/" "RerF/blob/{revision}/" "Python/{path}#L{lineno}",
 )
+
+napoleon_numpy_docstring = True
+
+
+def setup(app):
+    # to hide/show the prompt in code examples:
+    app.add_javascript("js/copybutton.js")
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx==1.8.5
 sphinx_rtd_theme==0.4.3
-numpydoc==0.8.0


### PR DESCRIPTION
adds javascript to hide the python interpreter in the code examples that allows easier copying of examples from the docs

got the idea from sklearn's docs in which they use the same file: https://scikit-learn.org/stable/_static/js/copybutton.js

original source is apparently from cpython itself: https://github.com/python/cpython/blob/3.7/Doc/tools/static/copybutton.js -- license is compatible with Apache.

Also in this PR, made a very small modification to the sphinx config to use sphinx.ext.napoleon instead of numpydoc as we can now use built in support for numpy formatted docstrings