### PR TITLE
update travis with eigen dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,76 @@
 matrix:
   include:
-  - language: r
-    sudo: false
-    cache: packages
+    - language: r
+      sudo: false
+      cache: packages
 
-    warnings_are_errors: false
+      warnings_are_errors: false
 
-    r:
-      - release
+      r:
+        - release
 
-    addons:
-      apt:
-        packages:
-          - libgsl0-dev
+      addons:
+        apt:
+          packages:
+            - libgsl0-dev
+            - libeigen3-dev
 
-    r_packages:
-      - devtools
-      - testthat
-      - Rcpp
+      r_packages:
+        - devtools
+        - testthat
+        - Rcpp
 
-    before_install:
-      - cd R-Project
+      before_install:
+        - cd R-Project
 
-    script:
-      - printf "Starting install and test with devtools.\n\n"
-      - Rscript -e "Rcpp::compileAttributes()"
-      ## The next 2 lines were a fix for lines 35-6
-      - Rscript -e "install.packages('./', type = 'source', repos = NULL)"
-      - Rscript -e "devtools::test(stop_on_failure = FALSE)"
-      ## The following won't work until we fix the ../../packedForest -> R-Project/src problem
-      #- printf "Starting BUILD and CHECK --as-cran\n\n"
-      #- R CMD build --resave-data .
-      #- R CMD check --as-cran --no-manual rerf*.tar.gz
-      - Rscript travisTest/test-on-prior-release.R
-  
-  - language: cpp
-    dist: xenial
-    sudo: false
-    compiler: 
-      - gcc
+      script:
+        - printf "Starting install and test with devtools.\n\n"
+        - Rscript -e "Rcpp::compileAttributes()"
+        ## The next 2 lines were a fix for lines 35-6
+        - Rscript -e "install.packages('./', type = 'source', repos = NULL)"
+        - Rscript -e "devtools::test(stop_on_failure = FALSE)"
+        ## The following won't work until we fix the ../../packedForest -> R-Project/src problem
+        #- printf "Starting BUILD and CHECK --as-cran\n\n"
+        #- R CMD build --resave-data .
+        #- R CMD check --as-cran --no-manual rerf*.tar.gz
+        - Rscript travisTest/test-on-prior-release.R
 
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
-          - g++-6 
+    - language: cpp
+      dist: xenial
+      sudo: false
+      compiler:
+        - gcc
 
-    before_install:
-    - cd packedForest
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - libeigen3-dev
 
-    script:
-      - make
-      - cd test
-      - make
+      before_install:
+        - cd packedForest
 
-  - language: python
-    dist: xenial
-    python: 
-      - "3.6"
-    before_install: cd Python
-    install: 
-      - pip install -r requirements.txt
-      - pip install -e .
-      - cd ..
-    script:
-      - pytest
-    
+      script:
+        - make
+        - cd test
+        - make
+
+    - language: python
+      dist: xenial
+      python:
+        - "3.6"
+
+      addons:
+        apt:
+          packages:
+            - libeigen3-dev
+
+      before_install: cd Python
+      install:
+        - pip install -r requirements.txt
+        - pip install -e .
+        - cd ..
+      script:
+        - pytest


### PR DESCRIPTION
This adds the eigen dependency to the travis build.  Travis still fails in C++ tests but not because of a dependency error.

Apologize for all the line changes this was done by my autoformatter: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

The only real change was adding 
            - libeigen3-dev
To each of the test platforms