### PR TITLE
Adds up to date instructions for installing Python module in OSX

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -98,7 +98,13 @@ class BuildExt(build_ext):
         ],
     }
 
+    l_opts = {"msvc": [], "unix": []}
+
     if sys.platform == "darwin":
+        darwin_opts = ["-stdlib=libc++", "-mmacosx-version-min=10.7"]
+        c_opts["unix"] += darwin_opts
+        l_opts["unix"] += darwin_opts
+
         ompbase = subprocess.run(["brew", "--prefix", "libomp"], stdout=subprocess.PIPE)
         omploc = ompbase.stdout.decode("utf-8").strip()
 
@@ -111,6 +117,7 @@ class BuildExt(build_ext):
     def build_extensions(self):
         ct = self.compiler.compiler_type
         opts = self.c_opts.get(ct, [])
+        link_opts = self.l_opts.get(ct, [])
         if ct == "unix":
             opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
             opts.append(cpp_flag(self.compiler))
@@ -120,6 +127,7 @@ class BuildExt(build_ext):
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
         for ext in self.extensions:
             ext.extra_compile_args = opts
+            ext.extra_link_args = link_opts
             if ct == "unix":
                 ext.extra_link_args = ["-lgomp"]
         build_ext.build_extensions(self)

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -135,7 +135,7 @@ setup(
     version=__version__,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    auther_email=AUTHOR_EMAIL,
+    author_email=AUTHOR_EMAIL,
     ext_modules=ext_modules,
     install_requires=required,
     cmdclass={"build_ext": BuildExt},

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,63 +2,110 @@ Install
 =======
 
 Below we assume you have the default Python environment already configured on
-your computer and you intend to install ``rerf`` inside of it.  If you want
-to create and work with Python virtual environments, please follow instructions
+your computer and you intend to install *RerF* inside of it.  We strongly 
+encourage the use of Python virtual environments, please follow instructions
 on `venv <https://docs.python.org/3/library/venv.html>`_ and `virtual
 environments <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_.
 
-First, make sure you have the latest version of ``pip`` (the Python package manager)
+Make sure you have the latest version of ``pip`` (the Python package manager)
 installed. If you do not, refer to the `Pip documentation
 <https://pip.pypa.io/en/stable/installing/>`_ and install ``pip`` first.
 
 Requirements
 ------------
 
-Python bindings use pybind11_.
+Currently *RerF* is available on :ref:`Linux <linux>` and :ref:`MacOS <mac>`.
 
-.. _pybind11: https://github.com/pybind/pybind11
+.. _linux:
 
-C++ compiler (gcc)::
+Linux
+`````
 
-  sudo apt-get install build-essential cmake python3-dev libomp-dev   # Ubuntu/Debian
-  
+Make sure you have the appropriate build tools
 
-On Mac:
+::
 
+    sudo apt-get install build-essential cmake python3-dev libomp-dev   # Ubuntu/Debian
+
+.. _mac:
+
+Mac
+```
+
+- Install the SDK headers (Mojave update removes SDK headers)
+
+  ::
+
+      open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 - Get `brew`_
-- ``brew install python3``
-- ``brew install libomp``
-- ``brew install llvm``
-- ``echo ‘export PATH=“/usr/local/opt/llvm/bin:$PATH”’ >> ~/.bash_profile``
-- ``export LDFLAGS=“-L/usr/local/opt/llvm/lib”``
-- ``export CPPFLAGS="-I/usr/local/opt/llvm/include"``
+
+  ::
+
+      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+- Get Python 3
+
+  ::
+
+      brew install python3
+
+- Get openmp (for multiprocessing)
+
+  ::
+
+      brew install libomp
+- Get llvm
+
+  ::
+
+      brew install llvm
+- Set up paths to use llvm's ``clang``
+
+  ::
+
+      echo ‘export PATH=“/usr/local/opt/llvm/bin:$PATH”’ >> ~/.bash_profile
+
+  Source your ``.bash_profile``
+
+  ::
+
+      source ~/.bash_profile
 
 .. _brew : https://brew.sh/
 
 
-Install from GitHub
--------------------
+Install
+-------
+
+From GitHub
+```````````
 
 ::
 
   pip install -e "git+https://github.com/neurodata/RerF.git@staging#egg=rerf&subdirectory=Python"
-  
 
 Build from source
------------------
+`````````````````
 
 - Get the source files
 
-``git clone https://github.com/neurodata/RerF.git``
+  ::
+
+      git clone https://github.com/neurodata/RerF.git
 
 - Navigate to Python directory
 
-``cd RerF/Python``
+  ::
 
-- Clean out old installation
+      cd RerF/Python
 
-``python setup.py clean --all``
+- Clean out old installation (skip if fresh install)
 
-- Build the package using `setup.py`
+  ::
 
-``pip install -e .``
+      python setup.py clean --all
+
+- Build using ``pip``
+
+  ::
+
+      pip install -e .


### PR DESCRIPTION
This mainly adds installation instructions for OSX mojave -- new requirement to (re-)install SDK.

`open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`

Also some minor tweaks to the `setup.py` file which I don't think matter much but also don't seem to break anything.