### PR TITLE
add test perfect training acc on iris (python)

### DIFF
--- a/Python/tests/test_rerfClassifier.py
+++ b/Python/tests/test_rerfClassifier.py
@@ -1,6 +1,8 @@
 # from the template test in sklearn:
 # https://github.com/scikit-learn-contrib/project-template/blob/master/skltemplate/tests/test_template.py
 
+import math
+
 import numpy as np
 import pytest
 from sklearn import datasets, metrics
@@ -8,7 +10,6 @@ from sklearn.utils.testing import assert_allclose, assert_array_equal
 from sklearn.utils.validation import check_random_state
 
 from rerf.rerfClassifier import rerfClassifier
-
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -107,8 +108,22 @@ def test_iris_perfect_train(projection_matrix):
     iris_full = datasets.load_iris()
     y_train_acc_list = []
     clf = rerfClassifier(n_estimators=100, projection_matrix=projection_matrix)
-    for i in range(100):
+
+    n_forests_to_try = 100
+    for i in range(n_forests_to_try):
         clf.fit(iris_full.data, iris_full.target)
         y_pred_train = clf.predict(iris_full.data)
         y_train_acc_list.append(metrics.accuracy_score(iris_full.target, y_pred_train))
-    assert all([yt == 1 for yt in y_train_acc_list])
+
+    correct_list = [math.isclose(yt, 1) for yt in y_train_acc_list]
+    if projection_matrix == "RerF":
+        # assert that we get it 100% correct all the time for RerF
+        # actual accuracy was 9998 / 10K runs (5/30/2019)
+        assert all(correct_list)
+    elif projection_matrix == "Base":
+        # assert that we get it 100% correct most of the time for RF
+        # actual accuracy was 9998 / 10K runs (5/30/2019)
+        assert sum(correct_list) >= 0.99 * n_forests_to_try
+
+        # want to make sure that if any are not giving 100% acc, it's only 1 obs that's wrong
+        assert min(y_train_acc_list) >= (1 - 1 / len(iris_full.target))

--- a/Python/tests/test_rerfClassifier.py
+++ b/Python/tests/test_rerfClassifier.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import pytest
-from sklearn import datasets
+from sklearn import datasets, metrics
 from sklearn.utils.testing import assert_allclose, assert_array_equal
 from sklearn.utils.validation import check_random_state
 
@@ -100,3 +100,15 @@ def check_iris_criterion(projection_matrix):
 @pytest.mark.parametrize("projection_matrix", ("RerF", "Base"))
 def test_iris(projection_matrix):
     check_iris_criterion(projection_matrix)
+
+
+@pytest.mark.parametrize("projection_matrix", ("RerF", "Base"))
+def test_iris_perfect_train(projection_matrix):
+    iris_full = datasets.load_iris()
+    y_train_acc_list = []
+    clf = rerfClassifier(n_estimators=100, projection_matrix=projection_matrix)
+    for i in range(100):
+        clf.fit(iris_full.data, iris_full.target)
+        y_pred_train = clf.predict(iris_full.data)
+        y_train_acc_list.append(metrics.accuracy_score(iris_full.target, y_pred_train))
+    assert all([yt == 1 for yt in y_train_acc_list])

--- a/docs/demos.rst
+++ b/docs/demos.rst
@@ -7,3 +7,4 @@ Demos
 
    demos/basic_usage
    demos/sklearn_classifier_comparison
+   demos/iris_perfect_test

--- a/docs/demos/iris_perfect_test.ipynb
+++ b/docs/demos/iris_perfect_test.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
     "from sklearn import metrics\n",
     "\n",
     "# https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wilcoxon.html\n",
-    "from scipy.stats import wilcoxon\n",
+    "from scipy.stats import mannwhitneyu\n",
     "\n",
     "# testing sklearn random forest\n",
     "from sklearn.ensemble import RandomForestClassifier\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,15 +72,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 10000/10000 [01:18<00:00, 127.03it/s]\n",
-      "  0%|          | 38/10000 [00:00<00:52, 188.92it/s]"
+      "100%|██████████| 10000/10000 [01:25<00:00, 117.23it/s]\n",
+      "  0%|          | 18/10000 [00:00<00:58, 171.45it/s]"
      ]
     },
     {
@@ -88,16 +88,16 @@
      "output_type": "stream",
      "text": [
       "RerF\n",
-      "10000\n",
-      "[1.0, 1.0, 1.0, 1.0, 1.0]\n"
+      "9997\n",
+      "[0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 1.0, 1.0]\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 10000/10000 [00:53<00:00, 185.46it/s]\n",
-      "  0%|          | 2/10000 [00:00<10:49, 15.39it/s]"
+      "100%|██████████| 10000/10000 [00:57<00:00, 174.98it/s]\n",
+      "  0%|          | 2/10000 [00:00<09:54, 16.81it/s]"
      ]
     },
     {
@@ -105,7 +105,7 @@
      "output_type": "stream",
      "text": [
       "RF\n",
-      "9962\n",
+      "9966\n",
       "[0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333]\n"
      ]
     },
@@ -113,7 +113,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 10000/10000 [10:42<00:00, 15.64it/s]"
+      "100%|██████████| 10000/10000 [09:06<00:00, 17.39it/s]"
      ]
     },
     {
@@ -121,7 +121,7 @@
      "output_type": "stream",
      "text": [
       "sklearn\n",
-      "9982\n",
+      "9972\n",
       "[0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333]\n"
      ]
     },
@@ -152,25 +152,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def two_sided_mannwhitneyu(x,y):\n",
+    "    u, prob_one_sided = mannwhitneyu(x, y, use_continuity=False)\n",
+    "    prob = prob_one_sided*2\n",
+    "\n",
+    "    return u, prob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WilcoxonResult(statistic=0.0, pvalue=7.074463098970675e-10)\n",
-      "WilcoxonResult(statistic=0.0, pvalue=2.209049699858536e-05)\n",
-      "WilcoxonResult(statistic=513.0, pvalue=0.007526315166457887)\n",
-      "WilcoxonResult(statistic=0.0, pvalue=7.74421643104407e-06)\n"
+      "RerF vs. RF:      p=0.000000337931825\n",
+      "RerF vs. sklearn: p=0.000007006066792\n",
+      "RF vs. sklearn:   p=0.445364679299948\n"
      ]
     }
    ],
    "source": [
-    "print(wilcoxon(rerf_acc, rf_acc))\n",
-    "print(wilcoxon(rerf_acc, sklearn_acc))\n",
-    "print(wilcoxon(rf_acc, sklearn_acc))\n",
-    "print(wilcoxon(sorted(rf_acc), sorted(sklearn_acc)))"
+    "_, prob_rerf_rf = two_sided_mannwhitneyu(rerf_acc, rf_acc)\n",
+    "_, prob_rerf_sklearn = two_sided_mannwhitneyu(rerf_acc, sklearn_acc)\n",
+    "_, prob_rf_sklearn = two_sided_mannwhitneyu(rf_acc, sklearn_acc)\n",
+    "\n",
+    "print(f\"RerF vs. RF:      p={prob_rerf_rf:0.15f}\")\n",
+    "print(f\"RerF vs. sklearn: p={prob_rerf_sklearn:0.15f}\")\n",
+    "print(f\"RF vs. sklearn:   p={prob_rf_sklearn:0.15f}\")"
    ]
   }
  ],

--- a/docs/demos/iris_perfect_test.ipynb
+++ b/docs/demos/iris_perfect_test.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test perfect training accuracy on iris "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "from rerf.rerfClassifier import rerfClassifier\n",
+    "\n",
+    "# Import scikit-learn dataset library\n",
+    "from sklearn import datasets\n",
+    "\n",
+    "# Import scikit-learn metrics module for accuracy calculation\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "# https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wilcoxon.html\n",
+    "from scipy.stats import wilcoxon\n",
+    "\n",
+    "# testing sklearn random forest\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "\n",
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load dataset\n",
+    "iris = datasets.load_iris()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def iris_pred_acc(cls, n_iter=10000):\n",
+    "    y_train_acc_list = []\n",
+    "    for i in tqdm(range(n_iter)):\n",
+    "        clf.fit(iris.data, iris.target)\n",
+    "        y_pred_train = clf.predict(iris.data)\n",
+    "        y_train_acc_list.append(metrics.accuracy_score(iris.target, y_pred_train))\n",
+    "        \n",
+    "    return y_train_acc_list "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_pred_summ(acc_list):\n",
+    "    print(sum([math.isclose(yt, 1) for yt in acc_list]))\n",
+    "    # print(\"avg acc\", sum(y_train_acc_list)/len(y_train_acc_list))\n",
+    "    print(sorted(acc_list)[0:5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [01:18<00:00, 127.03it/s]\n",
+      "  0%|          | 38/10000 [00:00<00:52, 188.92it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RerF\n",
+      "10000\n",
+      "[1.0, 1.0, 1.0, 1.0, 1.0]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [00:53<00:00, 185.46it/s]\n",
+      "  0%|          | 2/10000 [00:00<10:49, 15.39it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RF\n",
+      "9962\n",
+      "[0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [10:42<00:00, 15.64it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sklearn\n",
+      "9982\n",
+      "[0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333, 0.9933333333333333]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "clf = rerfClassifier(n_estimators=100, projection_matrix=\"RerF\")\n",
+    "rerf_acc = iris_pred_acc(clf, 10000)\n",
+    "print(\"RerF\")\n",
+    "print_pred_summ(rerf_acc)\n",
+    "\n",
+    "clf = rerfClassifier(n_estimators=100, projection_matrix=\"Base\")\n",
+    "rf_acc = iris_pred_acc(clf, 10000)\n",
+    "print(\"RF\")\n",
+    "print_pred_summ(rf_acc)\n",
+    "\n",
+    "clf = RandomForestClassifier(n_estimators=100)\n",
+    "sklearn_acc = iris_pred_acc(clf, 10000)\n",
+    "print(\"sklearn\")\n",
+    "print_pred_summ(sklearn_acc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WilcoxonResult(statistic=0.0, pvalue=7.074463098970675e-10)\n",
+      "WilcoxonResult(statistic=0.0, pvalue=2.209049699858536e-05)\n",
+      "WilcoxonResult(statistic=513.0, pvalue=0.007526315166457887)\n",
+      "WilcoxonResult(statistic=0.0, pvalue=7.74421643104407e-06)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(wilcoxon(rerf_acc, rf_acc))\n",
+    "print(wilcoxon(rerf_acc, sklearn_acc))\n",
+    "print(wilcoxon(rf_acc, sklearn_acc))\n",
+    "print(wilcoxon(sorted(rf_acc), sorted(sklearn_acc)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds a test for the following:

full iris dataset using in training
100 trees
make prediction on the full iris dataset
given those parameters - we expect 100% prediction accuracy
we then run this 100 times and check to make sure we get 100% accuracy every time

@jbrowne6 is this the sort of thing you were thinking of?