### PR TITLE
update python to dev v2.0.5.1 for clarity

### DIFF
--- a/Python/rerf/__init__.py
+++ b/Python/rerf/__init__.py
@@ -3,7 +3,7 @@ py-RerF
 """
 
 
-__version__ = "2.0.5"
+__version__ = "2.0.5.1"
 
 
 def check_version():


### PR DESCRIPTION
 I know we don't normally do this, but I wanted to make sure I could tag this version and specifically check for it after it's installed.

